### PR TITLE
Add lib/image_processing.rb, to make gem bundler-friendly

### DIFF
--- a/lib/image_processing.rb
+++ b/lib/image_processing.rb
@@ -1,0 +1,3 @@
+module ImageProcessing
+  autoload :MiniMagick, 'image_processing/mini_magick'
+end


### PR DESCRIPTION
This makes `Bundler.require` works fine and load `ImageProcessing` when there is `gem 'image_processing'` in Gemfile.