### PR TITLE
Automatically sharpen images after resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* [minimagick] Automatically sharpen thumbnails after resizing (@janko-m, @mokolabs)
+
 * [vips] Automatically sharpen thumbnails after resizing (@janko-m, @mokolabs)
 
 ## 0.11.2 (2018-03-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* [vips] Automatically sharpen thumbnails after resizing (@janko-m, @mokolabs)
+
 ## 0.11.2 (2018-03-31)
 
 * [minimagick] Avoid `#resize_*` operations stripping data by switching back to `-resize` (@janko-m)

--- a/doc/minimagick.md
+++ b/doc/minimagick.md
@@ -291,10 +291,42 @@ Sets the pixel cache resource limits for the ImageMagick command.
 ImageProcessing::MiniMagick
   .limits(memory: "50MiB", width: "10MP", time: 30)
   .resize_to_limit(400, 400)
-  .call(image) # convert -limit memory 50MiB -limit width 10MP -limit time 30 input.jpg ... output.jpg
+  .call(image)
+
+# convert -limit memory 50MiB -limit width 10MP -limit time 30 input.jpg ... output.jpg
 ```
 
 See the [`-limit`] documentation and the [Architecture] article.
+
+## Sharpening
+
+All `#resize_*` operations will automatically sharpen the resulting thumbnails
+after resizing, using the [`-sharpen`] option.
+
+```rb
+ImageProcessing::MiniMagick
+  .source(image)
+  .resize_to_limit!(400, 400)
+
+# convert input.jpg -resize 400x400> -sharpen 0x1 output.jpg
+```
+
+You can modify the radius and sigma of the Gaussian operator via the `:sharpen`
+option (higher sigma means more sharpening):
+
+```rb
+ImageProcessing::MiniMagick
+  .source(image)
+  .resize_to_limit!(400, 400, sharpen: { radius: 1, sigma: 2 })
+```
+
+You can disable automatic sharpening by setting `:sharpen` to `false`:
+
+```rb
+ImageProcessing::MiniMagick
+  .source(image)
+  .resize_to_limit!(400, 400, sharpen: false)
+```
 
 [MiniMagick]: https://github.com/minimagick/minimagick
 [ImageMagick]: https://www.imagemagick.org
@@ -309,3 +341,4 @@ See the [`-limit`] documentation and the [Architecture] article.
 [Writing JPEG Control Options]: http://www.imagemagick.org/Usage/formats/#jpg_write
 [`-limit`]: https://www.imagemagick.org/script/command-line-options.php#limit
 [Architecture]: https://www.imagemagick.org/script/architecture.php#cache
+[`-sharpen`]: https://www.imagemagick.org/script/command-line-options.php#sharpen

--- a/doc/vips.md
+++ b/doc/vips.md
@@ -283,6 +283,39 @@ vips_image #=> #<Vips::Image ...>
 vips_image.write_to_file("/path/to/destination", **options)
 ```
 
+## Sharpening
+
+All `#resize_*` operations will automatically sharpen the resulting thumbnails
+after resizing, using the following [convolution mask]:
+
+```rb
+Vips::Image.new_from_array [
+  [-1, -1, -1],
+  [-1, 32, -1],
+  [-1, -1, -1]], 24
+```
+
+You can assign a different convolution mask via the `:sharpen` option:
+
+```rb
+sharpen_mask = Vips::Image.new_from_array [
+  [-1, -1, -1],
+  [-1, 24, -1],
+  [-1, -1, -1]], 16
+
+ImageProcessing::Vips
+  .source(image)
+  .resize_to_limit!(400, 400, sharpen: sharpen_mask)
+```
+
+You can disable automatic sharpening by setting `:sharpen` to `false`:
+
+```rb
+ImageProcessing::Vips
+  .source(image)
+  .resize_to_limit!(400, 400, sharpen: false)
+```
+
 [ruby-vips]: https://github.com/jcupitt/ruby-vips
 [libvips]: https://github.com/jcupitt/libvips
 [installation instructions]: https://github.com/jcupitt/libvips/wiki#building-and-installing
@@ -299,3 +332,4 @@ vips_image.write_to_file("/path/to/destination", **options)
 [`vips_jpegsave()`]: https://jcupitt.github.io/libvips/API/current/VipsForeignSave.html#vips-jpegsave
 [`vips_pngsave()`]: https://jcupitt.github.io/libvips/API/current/VipsForeignSave.html#vips-pngsave
 [direction]: http://jcupitt.github.io/libvips/API/current/libvips-conversion.html#VipsCompassDirection
+[convolution mask]: https://en.wikipedia.org/wiki/Kernel_(image_processing)

--- a/test/mini_magick_test.rb
+++ b/test/mini_magick_test.rb
@@ -182,6 +182,12 @@ describe "ImageProcessing::MiniMagick" do
       assert_similar expected, @pipeline.resize_to_limit!(400, 400)
     end
 
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_limit!(400, 400, sharpen: { sigma: 1 })
+      normal    = @pipeline.resize_to_limit!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
+
     deprecated "still supports the legacy API" do
       expected = @pipeline.resize_to_limit!(400, 400)
 
@@ -221,6 +227,12 @@ describe "ImageProcessing::MiniMagick" do
       assert_similar expected, @pipeline.resize_to_fit!(400, 400)
     end
 
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_fit!(400, 400, sharpen: { sigma: 1 })
+      normal    = @pipeline.resize_to_fit!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
+
     deprecated "still supports the legacy API" do
       expected = @pipeline.resize_to_fit!(400, 400)
 
@@ -256,6 +268,12 @@ describe "ImageProcessing::MiniMagick" do
       centre    = @pipeline.resize_to_fill!(400, 400)
       northwest = @pipeline.resize_to_fill!(400, 400, gravity: "NorthWest")
       refute_similar centre, northwest
+    end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_fill!(400, 400, sharpen: { sigma: 1 })
+      normal    = @pipeline.resize_to_fill!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
 
     deprecated "still supports the legacy API" do
@@ -308,6 +326,12 @@ describe "ImageProcessing::MiniMagick" do
       transparent = @pipeline.resize_and_pad!(400, 400, background: :transparent)
       default     = @pipeline.resize_and_pad!(400, 400)
       assert_similar transparent, default
+    end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_and_pad!(400, 400, sharpen: { sigma: 1 })
+      normal    = @pipeline.resize_and_pad!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
 
     deprecated "still supports the legacy API" do

--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -146,6 +146,12 @@ describe "ImageProcessing::Vips" do
     it "accepts thumbnail options" do
       assert_dimensions [400, 400], @pipeline.resize_to_limit!(400, 400, crop: :centre)
     end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_limit!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
+      normal    = @pipeline.resize_to_limit!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
   end
 
   describe "#resize_to_fit" do
@@ -183,6 +189,12 @@ describe "ImageProcessing::Vips" do
     it "accepts thumbnail options" do
       assert_dimensions [400, 400], @pipeline.resize_to_fit!(400, 400, crop: :centre)
     end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_fit!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
+      normal    = @pipeline.resize_to_fit!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
   end
 
   describe "#resize_to_fill" do
@@ -207,6 +219,12 @@ describe "ImageProcessing::Vips" do
       attention = @pipeline.resize_to_fill!(400, 400, crop: :attention)
       centre    = @pipeline.resize_to_fill!(400, 400, crop: :centre)
       refute_similar centre, attention
+    end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_to_fill!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
+      normal   = @pipeline.resize_to_fill!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
   end
 
@@ -247,6 +265,12 @@ describe "ImageProcessing::Vips" do
       pad  = @pipeline.resize_and_pad!(400, 400)
       crop = @pipeline.resize_and_pad!(400, 400, crop: :centre)
       refute_similar pad, crop
+    end
+
+    it "accepts sharpening options" do
+      sharpened = @pipeline.resize_and_pad!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
+      normal    = @pipeline.resize_and_pad!(400, 400, sharpen: false)
+      assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/janko-m/image_processing/issues/22 and https://github.com/janko-m/image_processing/issues/16#issuecomment-374677906, this adds automatic image sharpening after resizing to Vips and MiniMagick modules. We do this only for JPEG images by default, as lossless formats can grow significantly in file size, but the format list is configurable.

For the Vips module we were able to make the `:sharpen_formats` "extension-insensitive" thanks to the introspection capabilities of ruby-vips. But for MiniMagick I didn't see a way. I thought about parsing out the `identify -list format` output, but that adds almost 100ms overhead on my machine when cached (on first the execution time can be up to 1s), so I discarded that option.

@mokolabs Let me know if this looks good.

Closes #22