### PR TITLE
Update libvips links to use official 'libvips' project name for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ImageProcessing
 
 Provides higher-level image processing functionality that is commonly needed
-when accepting user uploads. Supports processing with [VIPS] and [ImageMagick].
+when accepting user uploads. Supports processing with [libvips] and [ImageMagick].
 
 The goal of this project is to have a single place where common image
 processing helper methods are maintained, instead of Paperclip, CarrierWave,
@@ -124,8 +124,8 @@ The `ImageProcessing::MiniMagick` functionality was extracted from
 
 [MIT](LICENSE.txt)
 
+[libvps]: http://jcupitt.github.io/libvips/
 [ImageMagick]: https://www.imagemagick.org
-[VIPS]: http://jcupitt.github.io/libvips/
 [`ImageProcessing::Vips`]: /doc/vips.md#imageprocessingvips
 [`ImageProcessing::MiniMagick`]: /doc/minimagick.md#imageprocessingminimagick
 [refile-mini_magick]: https://github.com/refile/refile-mini_magick

--- a/doc/vips.md
+++ b/doc/vips.md
@@ -166,8 +166,8 @@ File.extname(result.path)
 By default the original format is retained when writing the image to a file. If
 the source file doesn't have a file extension, the format will default to JPEG.
 Note: GIF support in ImageProcessing::Vips is limited. You can read GIF files
-(and convert to other formats), but you can't save GIF files. If you need full
-GIF support, we recommend using ImageProcessing::MiniMagick instead.
+(and convert them to other formats), but you can't save GIF files. If you need
+full GIF support, we recommend using ImageProcessing::MiniMagick instead.
 
 #### `#method_missing`
 

--- a/doc/vips.md
+++ b/doc/vips.md
@@ -165,6 +165,9 @@ File.extname(result.path)
 
 By default the original format is retained when writing the image to a file. If
 the source file doesn't have a file extension, the format will default to JPEG.
+Note: GIF support in ImageProcessing::Vips is limited. You can read GIF files
+(and convert to other formats), but you can't save GIF files. If you need full
+GIF support, we recommend using ImageProcessing::MiniMagick instead.
 
 #### `#method_missing`
 


### PR DESCRIPTION
Made minor copy edits to the README.

Since `VIPS` isn't a real name, I think it's better to use the official `libvips` name in the README. This is separate, of course, from the `Vips` module name within image_processing itself.

I also reordered the links so that the libvps link is first (following the general pattern in our documentation and code of libvips appearing first and then followed by ImageMagick).