### PR TITLE
[minimagick] Disallow splitting layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## HEAD
 
-* [minimagick] Disallow splitting multi-layer images into multiple single-layer images (@janko-m)
+* [minimagick] Disallow splitting multi-layer images into multiple single-layer
+  images by default to avoid unexpected behaviour, but can be re-enabled with
+  the `:allow_splitting` saver option (@janko-m)
 
 * [core] Add `#apply` for applying a list of operations (@janko-m)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* [minimagick] Disallow splitting multi-layer images into multiple single-layer images (@janko-m)
+
 * [core] Add `#apply` for applying a list of operations (@janko-m)
 
 ## 1.0.0 (2018-04-04)

--- a/doc/minimagick.md
+++ b/doc/minimagick.md
@@ -263,10 +263,17 @@ ImageProcessing::MiniMagick
 It accepts the following special options:
 
 * `:define` -- definitions that coders and decoders use for reading and writing image data
+* `:allow_splitting` -- allow splitting multi-layer image into multiple single-layer images (defaults to `false`)
 
 ```rb
 ImageProcessing::MiniMagick.saver(define: { jpeg: { optimize_coding: false } }).call(image)
 # convert input.jpg -regard-warnings -auto-orient -define jpeg:optimize-coding=false output.jpg
+
+ImageProcessing::MiniMagick.convert("png").call(pdf_document)
+# raises ImageProcessing::Error
+
+ImageProcessing::MiniMagick.convert("png").saver(allow_splitting: true).call(pdf_document)
+# lets ImageMagick generate a "*-{idx}.png" image for each page
 ```
 
 All other options given will be interpreted as direct options to be applied


### PR DESCRIPTION
I've seen countless times that people get confused when converting a PDF into a PNG image raises weird exceptions. This is because when a multi-layer image is being converted into a single-layer format, ImageMagick will write each layer into a separate file, with "-{idx}" appended to each image. That causes an exception eventually, because the destination path which is expected to hold the processed file ends up empty.

I think that ImageProcessing should raise an exception in this case, and instruct the user that they should process individual pages instead. I first thought we could update ImageProcessing to automatically handle a multi-image output, but that would mean the resulting images wouldn't be Tempfiles, which could cause disk overflows if the user doesn't manually delete them. Also, libvips doesn't have the same behaviour: when you do the same with livips, it will append all pages one above the other in the resulting image.

To help users with processing each individual page, I'm linking them to the wiki article which describes that. My only concern is that processing each layer individually might be slower than letting ImageMagick process all layers at once, maybe we should test that.

Finally, we provide the `:allow_splitting` option to enable users to still use this ImageMagick feature. That way they can opt in only if they know what they're doing.

@mokolabs What do you think?