### PR TITLE
Fix "warning: shadowing outer local variable - options"

### DIFF
--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -46,10 +46,10 @@ module ImageProcessing
       def define(magick, options)
         return magick.define(options) if options.is_a?(String)
 
-        options.each do |namespace, options|
+        options.each do |namespace, magick_options|
           namespace = namespace.to_s.gsub("_", "-")
 
-          options.each do |key, value|
+          magick_options.each do |key, value|
             key = key.to_s.gsub("_", "-")
 
             magick.define "#{namespace}:#{key}=#{value}"


### PR DESCRIPTION
This fixes following warning:

```
lib/ruby/gems/2.5.0/gems/image_processing-1.2.0/lib/image_processing/mini_magick.rb:49: warning: shadowing outer local variable - options
```