### PR TITLE
Add #rotate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* [minimagick, vips] Add `#rotate` function (@janko-m)
+
 ## 1.2.0 (2018-04-18)
 
 * [minimagick] Allow appending "+" operators in `#loader` and `#saver` using the value `false` (@janko-m)

--- a/doc/minimagick.md
+++ b/doc/minimagick.md
@@ -161,6 +161,27 @@ It accepts `:gravity` for specifying the [gravity] to apply while cropping
 pipeline.resize_and_pad!(400, 400, gravity: "NorthWest")
 ```
 
+#### `#rotate`
+
+Rotates the image by the specified angle. Accepts any value that [`-rotate`]
+accepts.
+
+```rb
+ImageProcessing::MiniMagick
+  .rotate(90)
+  # ...
+```
+
+For degrees that are not a multiple of 90, you can also specify a background
+[color] for the empty triangles in the corners, left over from rotating the
+image.
+
+```rb
+ImageProcessing::Vips
+  .rotate(45, background: :transparent)
+  # ...
+```
+
 #### `#convert`
 
 Specifies the output format.
@@ -413,3 +434,4 @@ ImageProcessing::MiniMagick
 [Architecture]: https://www.imagemagick.org/script/architecture.php#cache
 [`-sharpen`]: https://www.imagemagick.org/script/command-line-options.php#sharpen
 [`-define`]: https://www.imagemagick.org/script/command-line-options.php#define
+[`-rotate`]: https://www.imagemagick.org/script/command-line-options.php#rotate

--- a/doc/vips.md
+++ b/doc/vips.md
@@ -169,6 +169,25 @@ pipeline.resize_to_fill!(400, 400, linear: true)
 
 See [`vips_thumbnail()`] and [`vips_gravity()`] for more details.
 
+#### `#rotate`
+
+Rotates the image by the specified angle.
+
+```rb
+ImageProcessing::Vips
+  .rotate(90)
+  # ...
+```
+
+For degrees that are not a multiple of 90, you can also specify a background
+color for the empty triangles in the corners, left over from rotating the image.
+
+```rb
+ImageProcessing::Vips
+  .rotate(45, background: [0, 0, 0])
+  # ...
+```
+
 #### `#convert`
 
 Specifies the output format.

--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -43,6 +43,13 @@ module ImageProcessing
         magick.extent "#{width}x#{height}"
       end
 
+      def rotate(magick, degrees, background: nil)
+        background = "rgba(255,255,255,0.0)" if background.to_s == "transparent"
+
+        magick.background background
+        magick.rotate(degrees)
+      end
+
       def define(magick, options)
         return magick.define(options) if options.is_a?(String)
 

--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -49,6 +49,14 @@ module ImageProcessing
         image.gravity(gravity, width, height, **embed_options)
       end
 
+      def rotate(image, degrees, **options)
+        if degrees % 90 == 0
+          image.rot(:"d#{degrees % 360}")
+        else
+          image.similarity(angle: degrees, **options)
+        end
+      end
+
       def load_image(path_or_image, autorot: true, **options)
         if path_or_image.is_a?(::Vips::Image)
           image = path_or_image

--- a/test/mini_magick_test.rb
+++ b/test/mini_magick_test.rb
@@ -282,7 +282,7 @@ describe "ImageProcessing::MiniMagick" do
       refute_similar centre, northwest
     end
 
-    it "accepts transparent color" do
+    it "defaults background color to transparent" do
       transparent = @pipeline.resize_and_pad!(400, 400, background: :transparent)
       default     = @pipeline.resize_and_pad!(400, 400)
       assert_similar transparent, default
@@ -292,6 +292,29 @@ describe "ImageProcessing::MiniMagick" do
       sharpened = @pipeline.resize_and_pad!(400, 400, sharpen: { sigma: 1 })
       normal    = @pipeline.resize_and_pad!(400, 400, sharpen: false)
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
+  end
+
+  describe "#rotate" do
+    before do
+      @pipeline = ImageProcessing::MiniMagick.source(@portrait)
+    end
+
+    it "rotates the image by specifed number of degrees" do
+      assert_dimensions [600, 800], @pipeline.rotate!(0)
+      assert_dimensions [800, 600], @pipeline.rotate!(90)
+      assert_dimensions [600, 800], @pipeline.rotate!("180")
+      assert_dimensions [800, 600], @pipeline.rotate!(-90)
+    end
+
+    it "accepts background color" do
+      @pipeline.rotate!(45, background: "red")
+    end
+
+    it "accepts transparent background color" do
+      transparent = @pipeline.rotate!(45, background: :transparent)
+      default     = @pipeline.rotate!(45, background: "rgba(255,255,255,0.0)")
+      assert_similar transparent, default
     end
   end
 

--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -276,4 +276,31 @@ describe "ImageProcessing::Vips" do
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
   end
+
+  describe "#rotate" do
+    before do
+      @pipeline = ImageProcessing::Vips.source(@portrait)
+    end
+
+    it "rotates by muliples of 90" do
+      assert_dimensions [600, 800], @pipeline.rotate!(0)
+      assert_dimensions [800, 600], @pipeline.rotate!(90)
+      assert_dimensions [600, 800], @pipeline.rotate!(180)
+      assert_dimensions [800, 600], @pipeline.rotate!(270)
+    end
+
+    it "works for angles outside of 0-360 degrees" do
+      assert_dimensions [600, 800], @pipeline.rotate!(360)
+      assert_dimensions [800, 600], @pipeline.rotate!(450)
+      assert_dimensions [800, 600], @pipeline.rotate!(-90)
+    end
+
+    it "rotates by arbitrary angle" do
+      assert_dimensions [990, 990], @pipeline.rotate!(45)
+    end
+
+    it "accepts background color" do
+      assert_dimensions [990, 990], @pipeline.rotate!(45, background: [0, 0, 0])
+    end
+  end
 end


### PR DESCRIPTION
This adds the `#rotate` function that was discussed in #40. Few notes:

* Since ImageMagick's `-rotate` already accepts an arbitrary angle, I made `ImageProcessing::Vips#rotate` accept one as well so that the functionality matches.
* I wanted to default the background color for `ImageProcessing::MiniMagick#rotate` to `:transparent`, but that might break backwards compatibility for users who were already using the native `-rotate` along with `-background`, so I made the default color unspecified.
* I didn't know how to test whether a background color is applied, so there aren't any tests for that.

@sandstorm, @mokolabs what do you think?

Closes #40